### PR TITLE
Add todo list feature

### DIFF
--- a/src/main/java/com/example/demo/HomeController.java
+++ b/src/main/java/com/example/demo/HomeController.java
@@ -56,8 +56,8 @@ public class HomeController {
 		return "redirect:/Test";
 	}
 	
-	@GetMapping("/CrystalTest")
-	public String CrystalTest(
+        @GetMapping("/CrystalTest")
+        public String CrystalTest(
 
 		@RequestParam("id") int id,
 		@RequestParam("test") String test
@@ -70,6 +70,11 @@ public class HomeController {
     userService.CrystalTest(dto);
     return "redirect:/Test";
 }
+
+        @GetMapping("/todo")
+        public String todoPage() {
+                return "Todo";
+        }
 }
 		
 	

--- a/src/main/java/com/example/demo/TodoController.java
+++ b/src/main/java/com/example/demo/TodoController.java
@@ -1,0 +1,38 @@
+package com.example.demo;
+
+import java.util.List;
+
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.web.bind.annotation.*;
+
+import com.example.demo.model.Todo;
+import com.example.demo.service.TodoService;
+
+@RestController
+@RequestMapping("/api/todos")
+public class TodoController {
+
+    @Autowired
+    private TodoService service;
+
+    @GetMapping
+    public List<Todo> all() {
+        return service.getAll();
+    }
+
+    @PostMapping
+    public void add(@RequestBody Todo todo) {
+        service.addTodo(todo);
+    }
+
+    @DeleteMapping("/{id}")
+    public void delete(@PathVariable int id) {
+        service.deleteTodo(id);
+    }
+
+    @PutMapping("/{id}")
+    public void update(@PathVariable int id, @RequestBody Todo todo) {
+        todo.setId(id);
+        service.updateTodo(todo);
+    }
+}

--- a/src/main/java/com/example/demo/mapper/TodoMapper.java
+++ b/src/main/java/com/example/demo/mapper/TodoMapper.java
@@ -1,0 +1,15 @@
+package com.example.demo.mapper;
+
+import java.util.List;
+
+import org.apache.ibatis.annotations.Mapper;
+
+import com.example.demo.model.Todo;
+
+@Mapper
+public interface TodoMapper {
+    List<Todo> getAll();
+    int insert(Todo todo);
+    int delete(int id);
+    int update(Todo todo);
+}

--- a/src/main/java/com/example/demo/model/Todo.java
+++ b/src/main/java/com/example/demo/model/Todo.java
@@ -1,0 +1,22 @@
+package com.example.demo.model;
+
+public class Todo {
+    private int id;
+    private String content;
+
+    public int getId() {
+        return id;
+    }
+
+    public void setId(int id) {
+        this.id = id;
+    }
+
+    public String getContent() {
+        return content;
+    }
+
+    public void setContent(String content) {
+        this.content = content;
+    }
+}

--- a/src/main/java/com/example/demo/model/Todo.java
+++ b/src/main/java/com/example/demo/model/Todo.java
@@ -2,7 +2,7 @@ package com.example.demo.model;
 
 public class Todo {
     private int id;
-    private String content;
+    private String todo;
 
     public int getId() {
         return id;
@@ -12,11 +12,11 @@ public class Todo {
         this.id = id;
     }
 
-    public String getContent() {
-        return content;
+    public String getTOdo() {
+        return todo;
     }
 
-    public void setContent(String content) {
-        this.content = content;
+    public void setTOdo(String todo) {
+        this.todo = todo;
     }
 }

--- a/src/main/java/com/example/demo/service/TodoService.java
+++ b/src/main/java/com/example/demo/service/TodoService.java
@@ -1,0 +1,31 @@
+package com.example.demo.service;
+
+import java.util.List;
+
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.stereotype.Service;
+
+import com.example.demo.mapper.TodoMapper;
+import com.example.demo.model.Todo;
+
+@Service
+public class TodoService {
+    @Autowired
+    private TodoMapper mapper;
+
+    public List<Todo> getAll() {
+        return mapper.getAll();
+    }
+
+    public int addTodo(Todo todo) {
+        return mapper.insert(todo);
+    }
+
+    public int deleteTodo(int id) {
+        return mapper.delete(id);
+    }
+
+    public int updateTodo(Todo todo) {
+        return mapper.update(todo);
+    }
+}

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -5,7 +5,7 @@ spring.mvc.view.suffix=.jsp
 
 spring.datasource.driver-class-name=org.mariadb.jdbc.Driver
 #데이터베이스 링크
-spring.datasource.url=jdbc:mariadb://192.168.0.191:3306/test
+spring.datasource.url=jdbc:mariadb://127.0.0.1:3306/test
 #사용자 아이디
 spring.datasource.username=root
 #사용자 비밀번호

--- a/src/main/resources/mapper/Money.xml
+++ b/src/main/resources/mapper/Money.xml
@@ -1,0 +1,1 @@
+<?xml version="1.0" encoding="UTF-8"?>

--- a/src/main/resources/mapper/TodoMapper.xml
+++ b/src/main/resources/mapper/TodoMapper.xml
@@ -5,15 +5,15 @@ PUBLIC "-//mybatis.org//DTD Mapper 3.0//EN"
 
 <mapper namespace="com.example.demo.mapper.TodoMapper">
     <select id="getAll" resultType="Todo">
-        SELECT * FROM todo
+        SELECT * FROM todos
     </select>
     <insert id="insert" parameterType="Todo">
-        INSERT INTO todo (test) VALUES (#{content})
+        INSERT INTO todos (todo) VALUES (#{todo})
     </insert>
     <delete id="delete" parameterType="int">
-        DELETE FROM todo WHERE id = #{id}
+        DELETE FROM todos WHERE id = #{id}
     </delete>
     <update id="update" parameterType="Todo">
-        UPDATE todo SET test = #{content} WHERE id = #{id}
+        UPDATE todos SET todo = #{todo} WHERE id = #{id}
     </update>
 </mapper>

--- a/src/main/resources/mapper/TodoMapper.xml
+++ b/src/main/resources/mapper/TodoMapper.xml
@@ -1,0 +1,19 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE mapper
+PUBLIC "-//mybatis.org//DTD Mapper 3.0//EN"
+"http://mybatis.org/dtd/mybatis-3-mapper.dtd">
+
+<mapper namespace="com.example.demo.mapper.TodoMapper">
+    <select id="getAll" resultType="Todo">
+        SELECT * FROM todo
+    </select>
+    <insert id="insert" parameterType="Todo">
+        INSERT INTO todo (test) VALUES (#{content})
+    </insert>
+    <delete id="delete" parameterType="int">
+        DELETE FROM todo WHERE id = #{id}
+    </delete>
+    <update id="update" parameterType="Todo">
+        UPDATE todo SET test = #{content} WHERE id = #{id}
+    </update>
+</mapper>

--- a/src/main/webapp/WEB-INF/views/Todo.jsp
+++ b/src/main/webapp/WEB-INF/views/Todo.jsp
@@ -1,0 +1,60 @@
+<%@ page language="java" contentType="text/html; charset=UTF-8" pageEncoding="UTF-8"%>
+<!DOCTYPE html>
+<html>
+<head>
+<meta charset="UTF-8">
+<title>Todo List</title>
+</head>
+<body>
+<h1>Todo List</h1>
+<div id="list"></div>
+<input type="text" id="newTodo" placeholder="새 항목">
+<button onclick="addTodo()">추가</button>
+<script>
+function loadTodos(){
+    fetch('/api/todos')
+        .then(r => r.json())
+        .then(data => {
+            const list = document.getElementById('list');
+            list.innerHTML = '';
+            data.forEach(item => {
+                const div = document.createElement('div');
+                div.textContent = item.content;
+                const del = document.createElement('button');
+                del.textContent = '삭제';
+                del.onclick = () => removeTodo(item.id);
+                const edit = document.createElement('button');
+                edit.textContent = '수정';
+                edit.onclick = () => {
+                    const val = prompt('새 값', item.content);
+                    if(val !== null) updateTodo(item.id, val);
+                };
+                div.appendChild(del);
+                div.appendChild(edit);
+                list.appendChild(div);
+            });
+        });
+}
+function addTodo(){
+    const content = document.getElementById('newTodo').value;
+    if(content.trim() === '') return;
+    fetch('/api/todos', {
+        method:'POST',
+        headers:{'Content-Type':'application/json'},
+        body:JSON.stringify({content})
+    }).then(() => { document.getElementById('newTodo').value=''; loadTodos(); });
+}
+function removeTodo(id){
+    fetch('/api/todos/' + id, {method:'DELETE'}).then(loadTodos);
+}
+function updateTodo(id, content){
+    fetch('/api/todos/' + id, {
+        method:'PUT',
+        headers:{'Content-Type':'application/json'},
+        body:JSON.stringify({content})
+    }).then(loadTodos);
+}
+loadTodos();
+</script>
+</body>
+</html>

--- a/src/main/webapp/WEB-INF/views/Todo.jsp
+++ b/src/main/webapp/WEB-INF/views/Todo.jsp
@@ -2,59 +2,94 @@
 <!DOCTYPE html>
 <html>
 <head>
-<meta charset="UTF-8">
-<title>Todo List</title>
+  <meta charset="UTF-8">
+  <title>Todo List</title>
 </head>
 <body>
-<h1>Todo List</h1>
-<div id="list"></div>
-<input type="text" id="newTodo" placeholder="새 항목">
-<button onclick="addTodo()">추가</button>
-<script>
-function loadTodos(){
+  <h1>Todo List</h1>
+  <div id="list"></div>
+
+  <!-- 새 항목 입력 -->
+  <input type="text" id="newTodo" placeholder="새 항목">
+  <button onclick="addTodo()">추가</button>
+
+  <script>
+  // 1) 할 일 목록 불러와서 그리기
+  function loadTodos() {
     fetch('/api/todos')
-        .then(r => r.json())
-        .then(data => {
-            const list = document.getElementById('list');
-            list.innerHTML = '';
-            data.forEach(item => {
-                const div = document.createElement('div');
-                div.textContent = item.content;
-                const del = document.createElement('button');
-                del.textContent = '삭제';
-                del.onclick = () => removeTodo(item.id);
-                const edit = document.createElement('button');
-                edit.textContent = '수정';
-                edit.onclick = () => {
-                    const val = prompt('새 값', item.content);
-                    if(val !== null) updateTodo(item.id, val);
-                };
-                div.appendChild(del);
-                div.appendChild(edit);
-                list.appendChild(div);
-            });
+      .then(r => r.json())
+      .then(data => {
+        const list = document.getElementById('list');
+        list.innerHTML = '';            // 기존 목록 초기화
+
+        data.forEach(item => {
+          // ───────────────────────────────────
+          // ★ 여기서 item.content가 아니라 item.todo ★
+          const div = document.createElement('div');
+          div.textContent = item.todo;  // ← 수정된 부분
+
+          // 삭제 버튼
+          const del = document.createElement('button');
+          del.textContent = '삭제';
+          del.onclick = () => removeTodo(item.id);
+
+          // 수정 버튼
+          const edit = document.createElement('button');
+          edit.textContent = '수정';
+          edit.onclick = () => {
+            const val = prompt('새 값', item.todo);
+            if (val !== null && val.trim() !== '') {
+              updateTodo(item.id, val);
+            }
+          };
+
+          div.appendChild(del);
+          div.appendChild(edit);
+          list.appendChild(div);
         });
-}
-function addTodo(){
-    const content = document.getElementById('newTodo').value;
-    if(content.trim() === '') return;
+      })
+      .catch(console.error);
+  }
+
+  // 2) 새 할 일 추가
+  function addTodo() {
+    const text = document.getElementById('newTodo').value;
+    if (text.trim() === '') return;
+
     fetch('/api/todos', {
-        method:'POST',
-        headers:{'Content-Type':'application/json'},
-        body:JSON.stringify({content})
-    }).then(() => { document.getElementById('newTodo').value=''; loadTodos(); });
-}
-function removeTodo(id){
-    fetch('/api/todos/' + id, {method:'DELETE'}).then(loadTodos);
-}
-function updateTodo(id, content){
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      // ───────────────────────────────────
+      // ★ JSON 키도 content가 아니라 todo ★
+      body: JSON.stringify({ todo: text })  // ← 수정된 부분
+    })
+    .then(() => {
+      document.getElementById('newTodo').value = '';
+      loadTodos();
+    })
+    .catch(console.error);
+  }
+
+  // 3) 삭제 요청
+  function removeTodo(id) {
+    fetch('/api/todos/' + id, { method: 'DELETE' })
+      .then(loadTodos)
+      .catch(console.error);
+  }
+
+  // 4) 수정 요청
+  function updateTodo(id, newText) {
     fetch('/api/todos/' + id, {
-        method:'PUT',
-        headers:{'Content-Type':'application/json'},
-        body:JSON.stringify({content})
-    }).then(loadTodos);
-}
-loadTodos();
-</script>
+      method: 'PUT',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ todo: newText })  // ← 수정된 부분
+    })
+    .then(loadTodos)
+    .catch(console.error);
+  }
+
+  // 페이지 열리면 바로 로드
+  loadTodos();
+  </script>
 </body>
 </html>

--- a/src/main/webapp/WEB-INF/views/Todo.jsp
+++ b/src/main/webapp/WEB-INF/views/Todo.jsp
@@ -14,19 +14,17 @@
   <button onclick="addTodo()">추가</button>
 
   <script>
-  // 1) 할 일 목록 불러와서 그리기
+  // 1) 할 일 목록 불러오기
   function loadTodos() {
     fetch('/api/todos')
       .then(r => r.json())
       .then(data => {
         const list = document.getElementById('list');
-        list.innerHTML = '';            // 기존 목록 초기화
+        list.innerHTML = '';            
 
         data.forEach(item => {
-          // ───────────────────────────────────
-          // ★ 여기서 item.content가 아니라 item.todo ★
           const div = document.createElement('div');
-          div.textContent = item.todo;  // ← 수정된 부분
+          div.textContent = item.todo;  
 
           // 삭제 버튼
           const del = document.createElement('button');
@@ -59,9 +57,8 @@
     fetch('/api/todos', {
       method: 'POST',
       headers: { 'Content-Type': 'application/json' },
-      // ───────────────────────────────────
-      // ★ JSON 키도 content가 아니라 todo ★
-      body: JSON.stringify({ todo: text })  // ← 수정된 부분
+      
+      body: JSON.stringify({ todo: text }) 
     })
     .then(() => {
       document.getElementById('newTodo').value = '';
@@ -82,13 +79,12 @@
     fetch('/api/todos/' + id, {
       method: 'PUT',
       headers: { 'Content-Type': 'application/json' },
-      body: JSON.stringify({ todo: newText })  // ← 수정된 부분
+      body: JSON.stringify({ todo: newText })  
     })
     .then(loadTodos)
     .catch(console.error);
   }
 
-  // 페이지 열리면 바로 로드
   loadTodos();
   </script>
 </body>


### PR DESCRIPTION
## Summary
- implement new `Todo` model, mapper, and service
- add REST controller for `/api/todos`
- provide JSP page to manage todos via JavaScript
- map `/todo` URL to the new view

## Testing
- `mvn -q test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6859ee516658832b9a884f1d66fd5a3f